### PR TITLE
Fix refresh mappings handling

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -714,6 +714,7 @@ public class TinyRemapper {
 			fieldMap.clear();
 			for (MrjState state : mrjStates.values()) {
 				unmergeClasses(state);
+				state.dirty = true;
 			}
 
 			mappingsDirty = true;
@@ -787,6 +788,7 @@ public class TinyRemapper {
 			mappingsDirty = true;
 			mappingProviders.clear();
 			mappingProviders.addAll(providers);
+			dirty = true;
 		}
 	}
 


### PR DESCRIPTION
Didn't catch this last round of testing since I had an existing workspace.

Seems like this dirty flag needs to be set to properly repropagate the mappings.